### PR TITLE
fix bug with optional parameters

### DIFF
--- a/src/Template.test.ts
+++ b/src/Template.test.ts
@@ -10,14 +10,26 @@ describe("Template engine", () => {
 	const OPTION__1 = new Option("OPTION", () => "first");
 	const OPTION__2 = new Option("OPTION", () => "second");
 
+	const SPECIAL_OPTION_WITH_THREE_PARAMS = new Option<[number | undefined, number | undefined, number]>(
+		"SPEC_OPTION",
+		(value, args) => {
+			if (!args) throw new Error();
+
+			const [first = 2, second = 5, third] = args;
+
+			return `first_${first}__second_${second}__third_${third}`;
+		},
+	);
+
 	const RANGE = new Option<[number, number]>("RANGE", (value, range) => {
 		if (!range) return value;
 		const [start = 0, end = value.length] = range;
+		console.log(value, start, end);
 
 		return value.slice(start, end);
 	});
 
-	const REPEAT = new Option<[number | undefined, string]>("REPEAT", (value, args) => {
+	const REPEAT = new Option<[number | undefined, string | undefined]>("REPEAT", (value, args) => {
 		if (!args) throw new Error("Not enough arguments");
 		const [times, separator = ""] = args;
 		if (!times) throw new Error("Times parameter is missing");
@@ -73,19 +85,44 @@ describe("Template engine", () => {
 
 	test("options with parameters", () => {
 		const replace = Configure({
-			globalOptions: [RANGE],
+			globalOptions: [RANGE, REPEAT, UPPER],
 			variables: [FILENAME],
 		});
 
 		const text1 = "$[FILENAME:RANGE(0, 3)]";
-		const text2 = "$[FILENAME:RANGE(12)]";
-		const text3 = "$[FILENAME:RANGE(, 11)]";
-		const text4 = "$[FILENAME:RANGE]";
 
 		expect(replace(text1)).toBe("app");
+	});
+
+	test("options with optional parameters", () => {
+		const replace = Configure({
+			globalOptions: [RANGE, REPEAT, SPECIAL_OPTION_WITH_THREE_PARAMS],
+			variables: [FILENAME],
+		});
+
+		const text1 = "$[FILENAME:WITHOUT_EXT:RANGE(0, )]";
+		const text2 = "$[FILENAME:RANGE(12)]";
+		const text3 = "$[FILENAME:WITHOUT_EXT:RANGE(, 11)]";
+		const text4 = "$[FILENAME:WITHOUT_EXT:RANGE]";
+		const text5 = "$[FILENAME:ONLY_EXT:REPEAT(3, |)]";
+		const text6 = "$[FILENAME:ONLY_EXT:REPEAT(5, )]";
+		const text7 = "$[FILENAME:ONLY_EXT:REPEAT(5)]";
+		const text8 = "$[FILENAME:ONLY_EXT:REPEAT(, |)]";
+		const text9 = "$[FILENAME:SPEC_OPTION(1, , 5)]";
+		const text10 = "$[FILENAME:SPEC_OPTION(, , 10)]";
+		const text11 = "$[FILENAME:SPEC_OPTION]";
+
+		expect(replace(text1)).toBe("application");
 		expect(replace(text2)).toBe("js");
 		expect(replace(text3)).toBe("application");
-		expect(replace(text4)).toBe("application.js");
+		expect(replace(text4)).toBe("application");
+		expect(replace(text5)).toBe("js|js|js");
+		expect(replace(text6)).toBe("jsjsjsjsjs");
+		expect(replace(text7)).toBe("jsjsjsjsjs");
+		expect(() => replace(text8)).toThrow();
+		expect(replace(text9)).toBe("first_1__second_5__third_5");
+		expect(replace(text10)).toBe("first_2__second_5__third_10");
+		expect(() => replace(text11)).toThrow();
 	});
 
 	test("option's combinations", () => {

--- a/src/models/Option/Option.ts
+++ b/src/models/Option/Option.ts
@@ -40,10 +40,14 @@ export class Option<Args extends Arg[] = Arg[]> {
 		}
 	}
 
-	private static parseArgs(argSeparator: string, args?: string): (string | number)[] | undefined {
-		if (args !== undefined)
-			return args.split(argSeparator).map((arg) => (Number.isNaN(Number(arg)) ? arg : Number(arg)));
-		return args;
+	private static parseArgs(argSeparator: string, args?: string): Arg[] | undefined {
+		if (args !== undefined) {
+			return args.split(argSeparator).map((arg) => {
+				if (!arg || arg === " ") return undefined;
+				if (!Number.isNaN(Number(arg))) return Number(arg);
+				else return arg;
+			});
+		}
 	}
 
 	/**


### PR DESCRIPTION
RUS:
Пофиксил баг с опциональными параметрами опций. Теперь вы можете делать вещи, вроде этих:
$[FILENAME:RANGE(3, )]. Однако будьте осторожны. Ваши опции должны обрабатывать такие ситуации, когда не все аргументы могут быть переданы. Иначе поведение такой опции может быть непредсказуемым.

ENG:
Fixed bug with optional parameters of options. Now you can do things like that:
$[FILENAME:RANGE(3, )]. However, be careful. Your options must handle situations, when not all arguments are passed. Otherwise, the behavior of such option can be unpredictable.